### PR TITLE
Run intval on SFTP resource.

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -202,7 +202,7 @@ class Sftp extends Subsystem
      */
     public function getUrl($filename)
     {
-        return sprintf('ssh2.sftp://%s/%s', $this->getResource(), $filename);
+        return sprintf('ssh2.sftp://%s/%s', intval($this->getResource()), $filename);
     }
 
     /**


### PR DESCRIPTION
It is necessary to execute `intval` on the Resource when parsing the SFTP url as of 5.6.28.

See: http://paul-m-jones.com/archives/6439